### PR TITLE
restrict extension access to love letter

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ The counts will automatically reset at the end of every round.
 
 ## Possible Improvements 
 1. Use an image of the deck as the icon instead of a `C`
-1. Specify the game table URL in the manifest
 1. Make the information appear on a popup page instead of a simple alert
 
 ## Background

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "permissions": ["activeTab"],
   "content_scripts": [
     {
-      "matches": ["<all_urls>"],
+      "matches": ["https://*.boardgamearena.com/6/loveletter*"],
       "js": ["content.js"]
     }
   ],

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "permissions": ["activeTab"],
   "content_scripts": [
     {
-      "matches": ["https://*.boardgamearena.com/6/loveletter*"],
+      "matches": ["https://*.boardgamearena.com/*/loveletter*"],
       "js": ["content.js"]
     }
   ],


### PR DESCRIPTION
Right now the extension loads (and crashes) on every site - this restricts it to running during love letter only